### PR TITLE
Move textareas onto different lines

### DIFF
--- a/editor/index.html
+++ b/editor/index.html
@@ -10,7 +10,9 @@
 <div id="textboxes" onkeyup="update()">
 <!-- Unfortunately having these <textarea>s on one line is actually necessary
   to remove a tiny amount of horizontal space between them -->
-<textarea id="html" placeholder="HTML" rows="9"></textarea><textarea id="css" placeholder="CSS" rows="9"></textarea><textarea id="javascript" placeholder="JavaScript" rows="9"></textarea>
+<textarea id="html" placeholder="HTML" rows="9"></textarea>
+<textarea id="css" placeholder="CSS" rows="9"></textarea>
+<textarea id="javascript" placeholder="JavaScript" rows="9"></textarea>
 </div>
 
 <div id="buttons">

--- a/editor/index.html
+++ b/editor/index.html
@@ -8,8 +8,6 @@
 
 <body onload="initialize()">
 <div id="textboxes" onkeyup="update()">
-<!-- Unfortunately having these <textarea>s on one line is actually necessary
-  to remove a tiny amount of horizontal space between them -->
 <textarea id="html" placeholder="HTML" rows="9"></textarea>
 <textarea id="css" placeholder="CSS" rows="9"></textarea>
 <textarea id="javascript" placeholder="JavaScript" rows="9"></textarea>

--- a/editor/main.css
+++ b/editor/main.css
@@ -11,6 +11,7 @@ html, body {
 #textboxes {
   height: 40%;
   width: 100%;
+  font-size: 0px;
 }
 
 textarea {


### PR DESCRIPTION
Learned that the `font-size` CSS property is what causes that little space in between